### PR TITLE
chore: Verify docker image can run help command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,7 @@ jobs:
     uses: "philipcristiano/workflows/.github/workflows/docker-build.yml@main"
     with:
       timeout: 25
+      check_command: "-h"
 
   rust:
     uses: "philipcristiano/workflows/.github/workflows/rust.yml@main"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.82 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.82-bookworm AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -16,6 +16,8 @@ RUN cargo build --release --bin owui-rag-sync
 # We do not need the Rust toolchain to run the binary!
 FROM debian:bookworm-slim
 WORKDIR /app
+RUN apt-get update && apt-get install openssl -y && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/target/release/owui-rag-sync /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/owui-rag-sync"]


### PR DESCRIPTION
Which should cause failures if the binary cannot be executed

Most commonly when build and run base images don't match